### PR TITLE
Relax the web-sys upper bound

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,6 @@ wasm-bindgen = "0.2"
 wasm-bindgen-derive = "0.2"
 wasm-bindgen-futures = "0.4"
 web-time = "1"
-web-sys = "0.3, <0.3.92"
+web-sys = "0.3"
 wgpu = { version = "29.0.0", default-features = false, features = ["metal", "wgsl", "webgl", "vulkan", "gles"] }
 winit = { version = "0.30", default-features = false }


### PR DESCRIPTION
Galileo pins `web-sys = "0.3, <0.3.92"` in the workspace manifest. Any project that already resolves a newer `web-sys` — which happens as soon as `wasm-bindgen` is updated — can't add Galileo at all:

```
error: failed to select a version for `web-sys`.
    ... required by package `galileo v0.2.1`
versions that meet the requirements `^0.3, <0.3.92` are: 0.3.91, 0.3.90, ...

all possible versions conflict with previously selected packages

  previously selected package `web-sys v0.3.103`
```

There's no way to work around this from downstream, because Cargo can patch a dependency's *source* but not its version bound.

This PR drops the ceiling to `web-sys = "0.3"`.

I tested it against `web-sys 0.3.103` in a workspace alongside `wasm-bindgen 0.2.x`. Galileo builds for both native and `wasm32-unknown-unknown`, and the wgpu renderer draws raster and vector tile layers unchanged — so the bound looks like it has outlived whatever it was originally added for.

If there is a specific incompatibility I've missed, I'm happy to reinstate a narrower bound instead.
