### PR TITLE
Fix build when another crate enables fontdb's fs feature

### DIFF
--- a/galileo/src/render/text/font_provider/font_db.rs
+++ b/galileo/src/render/text/font_provider/font_db.rs
@@ -38,6 +38,11 @@ impl FontProvider for FontdbFontProvider {
 
         match source {
             Source::Binary(data) => Some((Arc::new((*data).as_ref().to_vec()), index)),
+            // `fontdb::Source` gains file-backed variants when its `fs` feature is
+            // enabled, which any other crate in the dependency graph can do. This
+            // provider is wasm-only and has no filesystem, so it cannot use them.
+            #[allow(unreachable_patterns)]
+            _ => None,
         }
     }
 


### PR DESCRIPTION
`FontdbFontProvider::find_best_match` matches `fontdb::Source` with a single arm:

```rust
match source {
    Source::Binary(data) => Some((Arc::new((*data).as_ref().to_vec()), index)),
}
```

That is exhaustive only while `fontdb` is built *without* its `fs` feature. Cargo unifies features across the whole dependency graph, so if any other crate enables `fontdb/fs`, two more variants appear and Galileo stops compiling:

```
error[E0004]: non-exhaustive patterns: `fontdb::Source::File(_)` and
`fontdb::Source::SharedFile(_, _)` not covered
  --> galileo/src/render/text/font_provider/font_db.rs:39:15
```

This is easy to hit in practice, since `cosmic-text` and `usvg` both depend on `fontdb`. I ran into it building Galileo for `wasm32-unknown-unknown` in a workspace that also uses a GUI toolkit pulling in `cosmic-text` — nothing in my own code touches `fontdb` at all.

The fix adds a fallback arm returning `None`. This provider is wasm-only and already reports that it has no filesystem support (`load_fonts_folder` logs
"Fontdb provider doesn't support FS operations"), so file-backed sources aren't usable here regardless. `#[allow(unreachable_patterns)]` keeps the build
warning-free in the normal case where `fs` is off and the wildcard really is unreachable.
