### PR TITLE
Accept expressions and stops functions in text-field

### DIFF
--- a/galileo-maplibre/src/layer/vector_tile.rs
+++ b/galileo-maplibre/src/layer/vector_tile.rs
@@ -17,6 +17,7 @@ use serde::Deserialize;
 
 use crate::layer::{UNSUPPORTED, log_unsupported_field};
 use crate::style::color::MlColor;
+use crate::style::expression::MlExpr;
 use crate::style::layer::symbol::SymbolPlacement;
 use crate::style::layer::{FillLayer, Layer as MaplibreStyleLayer, LineLayer, SymbolLayer};
 use crate::style::source::{TileScheme, VectorSource};
@@ -299,7 +300,7 @@ fn symbol_rule(symbol: &SymbolLayer, tile_schema: &TileSchema) -> Option<StyleRu
         Some(SymbolPlacement::Point) | None => Some(StyleRule {
             layer_name: Some(source_layer),
             symbol: VectorTileSymbol::Label(VectorTileLabelSymbol {
-                pattern: symbol.layout.text_field.clone().unwrap_or_default(),
+                pattern: text_field_pattern(symbol),
                 text_style: style,
             }),
             min_resolution,
@@ -312,6 +313,36 @@ fn symbol_rule(symbol: &SymbolLayer, tile_schema: &TileSchema) -> Option<StyleRu
                 symbol.id
             );
             None
+        }
+    }
+}
+
+/// Resolve a symbol layer's `text-field` into a label pattern.
+///
+/// Galileo labels are token patterns such as `"{name}"`, which the renderer
+/// substitutes per feature. A `text-field` may instead be a modern expression or
+/// a legacy stops function, so translate the shapes that have an exact token
+/// equivalent and fall back to an empty pattern otherwise. An unsupported
+/// `text-field` costs the layer its labels rather than dropping the layer.
+fn text_field_pattern(symbol: &SymbolLayer) -> String {
+    let Some(text_field) = &symbol.layout.text_field else {
+        return String::new();
+    };
+
+    match text_field {
+        MlStyleValue::Literal(pattern) => pattern.clone(),
+        // `["get", "name"]` is exactly what the token `{name}` already means.
+        MlStyleValue::Expression(MlExpr::Get {
+            property,
+            object: None,
+        }) => format!("{{{property}}}"),
+        other => {
+            log::debug!(
+                "{UNSUPPORTED} 'symbol.layout.text-field' value {other:?} is not supported yet. \
+                 Layer '{}' renders without labels.",
+                symbol.id
+            );
+            String::new()
         }
     }
 }

--- a/galileo-maplibre/src/style/layer/mod.rs
+++ b/galileo-maplibre/src/style/layer/mod.rs
@@ -221,6 +221,32 @@ mod tests {
     }
 
     #[test]
+    fn text_field_accepts_a_token_string_an_expression_and_a_stops_function() {
+        // All three are valid `text-field` shapes in the style spec, and a layer
+        // whose `text-field` fails to parse is dropped entirely.
+        for text_field in [
+            r#""{name}""#,
+            r#"["get", "name"]"#,
+            r#"{"stops": [[2, "{ABBREV}"], [4, "{NAME}"]]}"#,
+        ] {
+            let json = format!(
+                r##"{{
+                    "id": "Labels",
+                    "type": "symbol",
+                    "source": "src",
+                    "layout": {{ "text-field": {text_field} }}
+                }}"##
+            );
+            let layer: Layer = serde_json::from_str(&json)
+                .unwrap_or_else(|error| panic!("text-field {text_field} failed to parse: {error}"));
+            let Layer::Symbol(symbol) = layer else {
+                panic!("expected Symbol")
+            };
+            assert!(symbol.layout.text_field.is_some(), "{text_field}");
+        }
+    }
+
+    #[test]
     fn parse_raster_layer() {
         let json = r#"{
             "id": "Satellite",

--- a/galileo-maplibre/src/style/layer/symbol.rs
+++ b/galileo-maplibre/src/style/layer/symbol.rs
@@ -252,7 +252,7 @@ pub struct SymbolLayout {
 
     /// Value to use for a text label. Supports expressions.
     #[serde(rename = "text-field", skip_serializing_if = "Option::is_none")]
-    pub text_field: Option<String>,
+    pub text_field: Option<MlStyleValue<String>>,
 
     /// Font stack for the glyphs. Supports expressions.
     #[serde(rename = "text-font", default = "default_font")]


### PR DESCRIPTION
`text-field` is typed as a plain `String`, but the style spec allows an expression
or a legacy stops function there too. Both fail to deserialize, and because a
layer that fails to parse is skipped entirely, a style using either loses its
label layers completely:

```
WARN galileo_maplibre::style] Failed to parse layer "countries-label":
invalid type: sequence, expected a string; skipping
```

Modern styles almost always write `["get", "name"]`, so this affects most
real-world label layers. MapLibre's own demotiles style hits it too, via
`{"stops": [[2, "{ABBREV}"], [4, "{NAME}"]]}`.

This changes the field to `Option<MlStyleValue<String>>`, matching how
`text-size`, `text-color` and `text-halo-width` already accept the same three
shapes.

Resolving it to a label pattern handles the cases with an exact token equivalent:
a literal string is used as-is, and `["get", "prop"]` becomes `"{prop}"`, which is
what that token already means to the renderer. Anything else logs an
unsupported-field message and yields an empty pattern, so the layer keeps
rendering its other properties instead of disappearing.

I deliberately did not try to reduce a `stops` function to a single pattern —
picking one zoom stop seemed like your call rather than mine.

Verified by rendering demotiles with `["get", "NAME"]` labels: the parse warning
is gone and the output is pixel-identical to a hand-written `"{NAME}"` token.
