### PR TITLE
Use WebGPU for headless rendering on wasm

### DIFF
--- a/galileo/src/render/wgpu/mod.rs
+++ b/galileo/src/render/wgpu/mod.rs
@@ -142,6 +142,13 @@ impl WgpuRenderer {
             .await
             .ok()?;
 
+        let info = adapter.get_info();
+        log::info!(
+            "Galileo wgpu adapter: {:?} backend, device \"{}\"",
+            info.backend,
+            info.name
+        );
+
         let (device, queue) = Self::create_device(&adapter).await;
 
         Some(Self {
@@ -374,6 +381,12 @@ impl WgpuRenderer {
         cfg_if! {
             if #[cfg(target_os = "android")] {
                 let backends = wgpu::Backends::GL;
+            } else if #[cfg(target_arch = "wasm32")] {
+                // WebGL2 cannot copy a texture into a buffer, so
+                // `new_with_texture_rt` plus `get_image` silently produce empty
+                // frames on the GL backend. Headless rendering on the web
+                // therefore requires WebGPU.
+                let backends = wgpu::Backends::BROWSER_WEBGPU;
             } else {
                 let backends = wgpu::Backends::all();
             }


### PR DESCRIPTION
`WgpuRenderer::new_with_texture_rt` renders into a texture, and `get_image` reads
it back with `copy_texture_to_buffer`. WebGL2 has no equivalent operation, so on
the GL backend that copy produces nothing and every frame comes back empty — with
no error, because both the submit and the buffer map appear to succeed.

`Backends::all()` on wasm lets the adapter request resolve to GL, so a browser
that fully supports WebGPU can still land on WebGL2 and silently render blank
frames.

This restricts wasm to `Backends::BROWSER_WEBGPU`, and logs the selected adapter
and backend so a surprising choice is visible rather than silent.

Context: I'm using Galileo headlessly on `wasm32-unknown-unknown` — rendering to a
texture and compositing the frames in a separate GPUI-based UI — and spent a while
chasing empty frames before thinking to check which backend had been chosen. The
log line alone would have saved most of that.

If you'd rather keep GL available on wasm for surface-based rendering, an
alternative would be to restrict the backend only in the texture-target
constructors, or to warn when a texture render target is created on GL. Happy to
rework it that way.
