### PR TITLE
Fix Clippy failure blocking all pull requests

### DIFF
--- a/galileo/src/render/render_bundle/world_set.rs
+++ b/galileo/src/render/render_bundle/world_set.rs
@@ -773,11 +773,8 @@ fn build_contour_path(
 ) -> Option<()> {
     let mut iterator = contour.iter_points();
 
-    if let Some(first_point) = iterator.next() {
-        let _ = path_builder.begin(point(first_point.x() * scale, first_point.y() * scale), &[]);
-    } else {
-        return None;
-    }
+    let first_point = iterator.next()?;
+    let _ = path_builder.begin(point(first_point.x() * scale, first_point.y() * scale), &[]);
 
     for p in iterator {
         let _ = path_builder.line_to(point(p.x() * scale, p.y() * scale), &[]);


### PR DESCRIPTION
The Clippy job currently fails on **every** pull request, including ones that
don't touch this file:

```
error: this block may be rewritten with the `?` operator
  --> galileo/src/render/render_bundle/world_set.rs:776:5
error: could not compile `galileo` (lib) due to 1 previous error
```

This isn't a regression. `main` last ran CI successfully on 2026-05-19 and the
code hasn't changed since — a newer stable clippy simply started firing
`question_mark` on it. Because the job runs with `-D warnings`, it's now a hard
failure for anyone opening a PR.

This rewrites the block as the lint suggests. Semantics are identical: the early
`return None` becomes `?`.

I hit this while opening a few other PRs and thought you'd rather have it fixed
than have every contributor wonder whether they broke something.
