### PR TITLE
Improve scrolling behaviour for trackpads

### DIFF
--- a/galileo-egui/src/egui_map.rs
+++ b/galileo-egui/src/egui_map.rs
@@ -8,7 +8,8 @@ use egui::{Event, Image, ImageSource, Sense, TextureId, Ui, Vec2};
 use egui_wgpu::RenderState;
 use egui_wgpu::wgpu::{FilterMode, TextureView};
 use galileo::control::{
-    EventProcessor, MapController, MouseButton, RawUserEvent, TouchEvent, UserEventHandler,
+    EventProcessor, MapController, MouseButton, RawUserEvent, SCROLL_LINE_MULTIPLIER,
+    SCROLL_PAGE_MULTIPLIER, TouchEvent, UserEventHandler,
 };
 use galileo::galileo_types::cartesian::{Point2, Size};
 use galileo::galileo_types::geo::impls::GeoPoint2d;
@@ -415,34 +416,18 @@ impl<'a> EguiMapState {
                 );
                 Some(RawUserEvent::PointerMoved(pointer_position))
             }
-            #[cfg(not(target_arch = "wasm32"))]
-            Event::MouseWheel { delta, .. } => {
-                let zoom = delta[1] as f64;
-
-                if zoom.abs() < 0.0001 {
-                    return None;
-                }
-
-                Some(RawUserEvent::Scroll(zoom))
-            }
-            #[cfg(target_arch = "wasm32")]
             Event::MouseWheel { delta, unit, .. } => {
-                // Winit produces different values in different browsers and they are all different
-                // from native platforms. See ttps://github.com/rust-windowing/winit/issues/22
-                //
-                // This hack is based on manual tests and might break in future. But this is the
-                // best I could come up with to mitigate the issue.
-                let zoom = match unit {
-                    egui::MouseWheelUnit::Point => delta[1] as f64 / 120.0,
-                    egui::MouseWheelUnit::Line => delta[1] as f64 / 6.0,
-                    egui::MouseWheelUnit::Page => delta[1] as f64,
+                let lines = match unit {
+                    egui::MouseWheelUnit::Point => delta[1] as f64 / SCROLL_LINE_MULTIPLIER,
+                    egui::MouseWheelUnit::Line => delta[1] as f64,
+                    egui::MouseWheelUnit::Page => delta[1] as f64 * SCROLL_PAGE_MULTIPLIER,
                 };
 
-                if zoom.abs() < 0.0001 {
+                if lines.abs() < 0.0001 {
                     return None;
                 }
 
-                Some(RawUserEvent::Scroll(zoom))
+                Some(RawUserEvent::Scroll(lines))
             }
             Event::Touch {
                 device_id: _,

--- a/galileo/src/control/event_processor.rs
+++ b/galileo/src/control/event_processor.rs
@@ -176,8 +176,8 @@ impl EventProcessor {
 
                 Some(events)
             }
-            RawUserEvent::Scroll(delta) => {
-                Some(vec![UserEvent::Scroll(delta, self.get_mouse_event())])
+            RawUserEvent::Scroll(lines) => {
+                Some(vec![UserEvent::Scroll(lines, self.get_mouse_event())])
             }
             RawUserEvent::TouchStart(touch) => {
                 for i in 0..self.touches.len() {

--- a/galileo/src/control/event_processor.rs
+++ b/galileo/src/control/event_processor.rs
@@ -176,8 +176,8 @@ impl EventProcessor {
 
                 Some(events)
             }
-            RawUserEvent::Scroll(lines) => {
-                Some(vec![UserEvent::Scroll(lines, self.get_mouse_event())])
+            RawUserEvent::Scroll(delta) => {
+                Some(vec![UserEvent::Scroll(delta, self.get_mouse_event())])
             }
             RawUserEvent::TouchStart(touch) => {
                 for i in 0..self.touches.len() {

--- a/galileo/src/control/map.rs
+++ b/galileo/src/control/map.rs
@@ -305,8 +305,8 @@ impl UserEventHandler for MapController {
                 }
                 _ => EventPropagation::Propagate,
             },
-            UserEvent::Scroll(delta, mouse_event) => {
-                let zoom = self.get_zoom(*delta);
+            UserEvent::Scroll(lines, mouse_event) => {
+                let zoom = self.get_zoom(*lines);
 
                 let target = map
                     .target_view()
@@ -353,8 +353,8 @@ impl UserEventHandler for MapController {
 }
 
 impl MapController {
-    fn get_zoom(&self, delta: f64) -> f64 {
-        (self.config.zoom_speed + 1.0).powf(-delta)
+    fn get_zoom(&self, lines: f64) -> f64 {
+        (self.config.zoom_speed + 1.0).powf(-lines)
     }
 
     fn get_rotation(&self, curr_view: &MapView, px_delta: Vector2) -> MapView {

--- a/galileo/src/control/map.rs
+++ b/galileo/src/control/map.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use galileo_types::cartesian::Vector2;
+use num_traits::Inv;
 
 use super::MouseEvent;
 use crate::control::{EventPropagation, MouseButton, UserEvent, UserEventHandler};
@@ -354,7 +355,9 @@ impl UserEventHandler for MapController {
 
 impl MapController {
     fn get_zoom(&self, delta: f64) -> f64 {
-        (self.config.zoom_speed + 1.0).powf(-delta)
+        let factor = 1.0 + self.config.zoom_speed * delta.abs();
+
+        if delta < 0.0 { factor } else { factor.inv() }
     }
 
     fn get_rotation(&self, curr_view: &MapView, px_delta: Vector2) -> MapView {

--- a/galileo/src/control/map.rs
+++ b/galileo/src/control/map.rs
@@ -305,8 +305,8 @@ impl UserEventHandler for MapController {
                 }
                 _ => EventPropagation::Propagate,
             },
-            UserEvent::Scroll(lines, mouse_event) => {
-                let zoom = self.get_zoom(*lines);
+            UserEvent::Scroll(delta, mouse_event) => {
+                let zoom = self.get_zoom(*delta);
 
                 let target = map
                     .target_view()
@@ -353,8 +353,8 @@ impl UserEventHandler for MapController {
 }
 
 impl MapController {
-    fn get_zoom(&self, lines: f64) -> f64 {
-        (self.config.zoom_speed + 1.0).powf(-lines)
+    fn get_zoom(&self, delta: f64) -> f64 {
+        (self.config.zoom_speed + 1.0).powf(-delta)
     }
 
     fn get_rotation(&self, curr_view: &MapView, px_delta: Vector2) -> MapView {

--- a/galileo/src/control/mod.rs
+++ b/galileo/src/control/mod.rs
@@ -22,6 +22,11 @@ mod map;
 pub use event_processor::EventProcessor;
 pub use map::{MapController, MapControllerConfiguration};
 
+/// In the context of scrolling text, how many pixels make up one line height of text?
+pub const SCROLL_LINE_MULTIPLIER: f64 = 20.0;
+/// In the context of scrolling text, how many pixels make up one page height of text?
+pub const SCROLL_PAGE_MULTIPLIER: f64 = SCROLL_LINE_MULTIPLIER * 6.0;
+
 /// User input handler.
 pub trait UserEventHandler {
     /// Handle the event.

--- a/galileo/src/winit.rs
+++ b/galileo/src/winit.rs
@@ -6,7 +6,7 @@ use galileo_types::cartesian::Point2;
 use winit::event::{ElementState, MouseScrollDelta, Touch, TouchPhase, WindowEvent};
 use winit::window::Window;
 
-use crate::control::{MouseButton, RawUserEvent, TouchEvent};
+use crate::control::{MouseButton, RawUserEvent, SCROLL_LINE_MULTIPLIER, TouchEvent};
 use crate::messenger::Messenger;
 
 /// Converts `winit` events into `Galileo` [`RawUserEvent`]s.
@@ -30,15 +30,16 @@ impl WinitInputHandler {
                 Some(RawUserEvent::PointerMoved(pointer_position))
             }
             WindowEvent::MouseWheel { delta, .. } => {
-                let zoom = match delta {
+                let lines = match delta {
+                    MouseScrollDelta::PixelDelta(pos) => pos.y / SCROLL_LINE_MULTIPLIER,
                     MouseScrollDelta::LineDelta(_, dy) => *dy as f64,
-                    MouseScrollDelta::PixelDelta(pos) => pos.y / 114.0,
                 };
-                if zoom.abs() < 0.0001 {
+
+                if lines.abs() < 0.0001 {
                     return None;
                 }
 
-                Some(RawUserEvent::Scroll(zoom))
+                Some(RawUserEvent::Scroll(lines))
             }
             WindowEvent::Touch(touch) => match touch.phase {
                 TouchPhase::Started => {


### PR DESCRIPTION
Fixed #345.

Re-scales the scroll deltas received from the OS events to have the line height units, following the behaviour described by existing comments.

The behaviour for taking the line height to be 20px is what the Zed IDE use for their image viewer scrolling.

I've tested the changes with a scroll wheel and trackpad on native & web.

Note: This PR had previously turned the scroll factor from exponential to linear, but I checked and discovered that simply re-scaling was enough to fix the issues with scrolling on my trackpad.

## Videos before
Trackpad before, on native
https://github.com/user-attachments/assets/0d3b5ced-e5b6-4140-8ec9-abb3bb0bbc18
(Low resolution if for filesize)

## Videos after
Trackpad after, on native

https://github.com/user-attachments/assets/d162ab70-5a2b-4eaa-8189-8c21967e1af6
(Low resolution if for filesize)